### PR TITLE
Feature/cancellation for student

### DIFF
--- a/src/Contollers/Assessment.controller.js
+++ b/src/Contollers/Assessment.controller.js
@@ -439,9 +439,10 @@ export const allAssessmentByTeacher = asyncHandler(async (req, res) => {
 export const getAllassessmentforStudent = asyncHandler(async (req, res) => {
   const studentId = req.user._id;
 
-  // 1. Get all enrollments
+  // 1. Get all ACTIVE enrollments (exclude CANCELLED)
   const allEnrollmentofStudent = await Enrollment.find({
     student: studentId,
+    status: { $ne: "CANCELLED" }
   });
 
     const courseIds = allEnrollmentofStudent.map(

--- a/src/Models/Enrollement.model.js
+++ b/src/Models/Enrollement.model.js
@@ -33,7 +33,7 @@ const EnrollmentSchema = new mongoose.Schema(
     stripeSessionId: { type: String },
     subscriptionId: { type: String },
     enrollmentType: { type: String, enum: ["ONETIME", "SUBSCRIPTION", "FREE", "TEACHERENROLLMENT"], required: true },
-    status: { type: String, enum: ["ACTIVE", "PAST_DUE", "CANCELLED", "TRIAL", "APPLIEDFORCANCEL", "CANCELLEDDDDDD"] },
+    status: { type: String, enum: ["ACTIVE", "PAST_DUE", "CANCELLED", "TRIAL", "APPLIEDFORCANCEL"] },
     stripeInvoiceId: { type: String },
     hasUsedTrial: {
       type: Boolean,

--- a/src/Routes/Annoucement.Routes.js
+++ b/src/Routes/Annoucement.Routes.js
@@ -8,11 +8,13 @@ import {
 } from "../Contollers/announcement.controller.js";
 import { isUser } from "../middlewares/Auth.Middleware.js";
 import { upload } from "../lib/multer.config.js";
+import { isEnrolledMiddleware } from "../middlewares/isEnrolled.middleware.js";
+import { resolveEnrollmentFromQuery } from "../middlewares/enrollment-resolvers.js";
 
 const router = express.Router();
 
 router.get("/getbystudent/:studentId", isUser, getAnnouncementsForStudent);
-router.get("/getannouncementforcourse", isUser, getAnnouncementsForCourse);
+router.get("/getannouncementforcourse", isUser, resolveEnrollmentFromQuery, isEnrolledMiddleware, getAnnouncementsForCourse);
 router.post("/createannouncement", isUser, upload.any(), createAnnouncement);
 router.get("/getbyteacher/:teacherId", isUser, getAnnouncementsByTeacher);
 router.delete("/:id", isUser, deleteAnnouncement);

--- a/src/Routes/Assessment.Routes.js
+++ b/src/Routes/Assessment.Routes.js
@@ -17,6 +17,8 @@ import { upload } from "../lib/multer.config.js";
 import { isUser } from "../middlewares/Auth.Middleware.js";
 import { getResultsMiddleware } from "../middlewares/isSubmitted.middleware.js";
 import { createAssessment_updated } from "../Contollers/UPDATED_API_CONTROLLER/assessment.controller.web.js";
+import { isEnrolledMiddleware } from "../middlewares/isEnrolled.middleware.js";
+import { resolveEnrollmentFromAssessment } from "../middlewares/enrollment-resolvers.js";
 
 const router = express.Router();
 
@@ -39,7 +41,7 @@ router.put(
   uploadFiles
 );
 router.delete("/deleteFile/:assessmentId/:fileId", deleteFile);
-router.get("/:assessmentId", isUser, getResultsMiddleware, getAssesmentbyID);
+router.get("/:assessmentId", isUser, resolveEnrollmentFromAssessment, isEnrolledMiddleware, getResultsMiddleware, getAssesmentbyID);
 
 router.put("/editAssessment/:assessmentId", isUser, editAssessmentInfo);
 

--- a/src/Routes/CourseRoutes/Chapter.Routes.js
+++ b/src/Routes/CourseRoutes/Chapter.Routes.js
@@ -9,15 +9,17 @@ import {
   getChapterwithLessons,
 } from "../../Contollers/CourseControllers/chapter.controller.js";
 import { isUser } from "../../middlewares/Auth.Middleware.js";
+import { isEnrolledMiddleware } from "../../middlewares/isEnrolled.middleware.js";
+import { resolveEnrollmentFromChapter } from "../../middlewares/enrollment-resolvers.js";
 
 const router = express.Router();
 
-router.get("/chapterofCourse/:courseId", isUser, ChapterofCourse);
+router.get("/chapterofCourse/:courseId", isUser, isEnrolledMiddleware, ChapterofCourse);
 router.post("/create/:courseId", isUser, createChapter);
 // router.get("/:quarterId", isUser, getChapterofCourse);
 router.delete("/:chapterId", isUser, deleteChapter);
 router.get("/:courseId/:quarterId", isUser, getChapterOfQuarter);
-router.get("/chapter/chapter&lessons/:chapterId", isUser, getChapterwithLessons);
+router.get("/chapter/chapter&lessons/:chapterId", isUser, resolveEnrollmentFromChapter, isEnrolledMiddleware, getChapterwithLessons);
 router.put("/edit/:chapterId", isUser, editChapter);
 
 

--- a/src/Routes/Stripe.Routes.js
+++ b/src/Routes/Stripe.Routes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { cancelSubscriptionAtPeriodEnd, checkOnboarding, createCheckoutSession, createCheckoutSessionConnect, createMobileCheckoutSession, getpurchases, getStripeLoginLink, stripeOnboarding } from '../Contollers/stripe.controller.js';
+import { cancelSubscriptionAtPeriodEnd, checkOnboarding, createCheckoutSession, createCheckoutSessionConnect, createMobileCheckoutSession, getpurchases, getStripeLoginLink, stripeOnboarding, undoCancellation, renewSubscription } from '../Contollers/stripe.controller.js';
 import { isUser } from '../middlewares/Auth.Middleware.js';
 
 const router = express.Router();
@@ -18,6 +18,8 @@ router.get("/getStripeLoginLink", isUser, getStripeLoginLink)
 router.post("/create-checkout-session-connect", isUser, createCheckoutSessionConnect)
 router.get("/getPurchases", isUser, getpurchases)
 router.post("/cancelSubscriptionAtPeriodEnd", isUser, cancelSubscriptionAtPeriodEnd)
+router.post("/undo-cancellation", isUser, undoCancellation)
+router.post("/renew-subscription", isUser, renewSubscription)
 
 /////for test only
 // router.post("/advance-test-clock", advanceTestClock)

--- a/src/Routes/Submission.Routes.js
+++ b/src/Routes/Submission.Routes.js
@@ -8,16 +8,20 @@ import {
   teacherGrading,
 } from "../Contollers/Submission.controller.js";
 import { upload } from "../lib/multer.config.js";
+import { isEnrolledMiddleware } from "../middlewares/isEnrolled.middleware.js";
+import { resolveEnrollmentFromAssessment, resolveEnrollmentFromSubmission } from "../middlewares/enrollment-resolvers.js";
 
 const router = express.Router();
 
 router.post(
   "/submission/:assessmentId",
   isUser,
+  resolveEnrollmentFromAssessment,
+  isEnrolledMiddleware,
   upload.array("files"),
   submission
 );
-router.get("/submission/:submissionId", isUser, getSubmissionById);
+router.get("/submission/:submissionId", isUser, resolveEnrollmentFromSubmission, isEnrolledMiddleware, getSubmissionById);
 router.get(
   "/submission_for_Teacher/:assessmentId",
   isUser,

--- a/src/middlewares/enrollment-resolvers.js
+++ b/src/middlewares/enrollment-resolvers.js
@@ -1,0 +1,92 @@
+import Chapter from "../Models/chapter.model.sch.js";
+import Assessment from "../Models/Assessment.model.js";
+import Submission from "../Models/submission.model.js";
+
+// Resolver for chapter-based routes - extracts courseId from chapterId
+export const resolveEnrollmentFromChapter = async (req, res, next) => {
+  try {
+    const { chapterId } = req.params;
+    
+    if (!chapterId) {
+      return res.status(400).json({ message: "Chapter ID is required" });
+    }
+
+    const chapter = await Chapter.findById(chapterId).select("course");
+    
+    if (!chapter) {
+      return res.status(404).json({ message: "Chapter not found" });
+    }
+
+    // Inject courseId into params for isEnrolledMiddleware
+    req.params.courseId = chapter.course.toString();
+    next();
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+// Resolver for assessment-based routes - extracts courseId from assessmentId
+export const resolveEnrollmentFromAssessment = async (req, res, next) => {
+  try {
+    const { assessmentId } = req.params;
+    
+    if (!assessmentId) {
+      return res.status(400).json({ message: "Assessment ID is required" });
+    }
+
+    const assessment = await Assessment.findById(assessmentId).select("course");
+    
+    if (!assessment) {
+      return res.status(404).json({ message: "Assessment not found" });
+    }
+
+    // Inject courseId into params for isEnrolledMiddleware
+    req.params.courseId = assessment.course.toString();
+    next();
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+// Resolver for submission-based routes - extracts courseId from submissionId
+export const resolveEnrollmentFromSubmission = async (req, res, next) => {
+  try {
+    const { submissionId } = req.params;
+    
+    if (!submissionId) {
+      return res.status(400).json({ message: "Submission ID is required" });
+    }
+
+    const submission = await Submission.findById(submissionId).populate({
+      path: "assessment",
+      select: "course"
+    });
+    
+    if (!submission) {
+      return res.status(404).json({ message: "Submission not found" });
+    }
+
+    // Inject courseId into params for isEnrolledMiddleware
+    req.params.courseId = submission.assessment.course.toString();
+    next();
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+// Resolver for query-based courseId - moves courseId from query to params
+export const resolveEnrollmentFromQuery = async (req, res, next) => {
+  try {
+    const courseId = req.query.courseId;
+    
+    if (!courseId) {
+      return res.status(400).json({ message: "Course ID is required in query" });
+    }
+
+    // Inject courseId into params for isEnrolledMiddleware
+    req.params.courseId = courseId.toString();
+    next();
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};

--- a/src/middlewares/isEnrolled.middleware.js
+++ b/src/middlewares/isEnrolled.middleware.js
@@ -4,17 +4,60 @@ export const isEnrolledMiddleware = async (req, res, next) => {
   const { courseId } = req.params;
   const userId = req.user._id;
   try {
-    const exists = await Enrollment.findOne({
+    let enrollment = await Enrollment.findOne({
       student: userId,
       course: courseId,
     });
-    if (!exists) {
+    
+    if (!enrollment) {
       return res
         .status(404)
         .json({ message: "You are not enrolled in this course" });
     }
+
+    console.log("=== ENROLLMENT CHECK ===");
+    console.log("Status:", enrollment.status);
+    console.log("Cancellation Date:", enrollment.cancellationDate);
+    console.log("Current Date:", new Date());
+    console.log("Date passed?", new Date() >= enrollment.cancellationDate);
+
+    // Auto-update APPLIEDFORCANCEL to CANCELLED if cancellation date has passed
+    if (enrollment.status === "APPLIEDFORCANCEL" && enrollment.cancellationDate) {
+      const now = new Date();
+      if (now >= enrollment.cancellationDate) {
+        console.log("🔄 Auto-updating status to CANCELLED");
+        enrollment.status = "CANCELLED";
+        await enrollment.save();
+        console.log("✅ Status updated successfully");
+      }
+    }
+
+    console.log("Final Status:", enrollment.status);
+
+    // Check if enrollment status allows access
+    const activeStatuses = ["ACTIVE", "TRIAL", "APPLIEDFORCANCEL", "PAST_DUE"];
+    
+    if (!activeStatuses.includes(enrollment.status)) {
+      // Status is CANCELLED - access denied but can renew
+      const canRenew = enrollment.enrollmentType === "SUBSCRIPTION" && 
+                       enrollment.status === "CANCELLED";
+      
+      console.log("❌ ACCESS DENIED - Status:", enrollment.status);
+      
+      return res.status(403).json({ 
+        message: "Your enrollment has been cancelled. Please renew your subscription to continue.",
+        canRenew,
+        enrollmentId: enrollment._id
+      });
+    }
+
+    console.log("✅ ACCESS GRANTED");
+
+    // Attach enrollment to request for potential use in controllers
+    req.enrollment = enrollment;
     next();
   } catch (err) {
+    console.error("Middleware error:", err);
     res.status(500).json({ error: err.message });
   }
 };


### PR DESCRIPTION
feature: implement subscription cancellation with grace period and renewal

- Add two-stage cancellation: APPLIEDFORCANCEL (grace period) → CANCELLED (blocked)
- Auto-update enrollment status when cancellation date passes
- Block cancelled students from accessing chapters, assessments, announcements, and submissions
- Add undo-cancellation and renew-subscription endpoints
- Preserve all student data (submissions, grades, progress) during cancellation
- Enable renewal with full data restoration
- Add enrollment middleware to all student-facing content routes
- Return 403 with canRenew flag for cancelled enrollments
- Filter cancelled enrollments from assessment and announcement lists